### PR TITLE
Add detection for removed methods and kwargs (QKT101/102/201/202)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,30 @@
 # flake8-qiskit-migration
 
-Flake8 plugin to detect deprecated/removed imports in Qiskit 1.0 and 2.0.
+Flake8 plugin to detect deprecated/removed imports, methods, and arguments in Qiskit 1.0 and 2.0.
 
-- **QKT100**: Imports deprecated in Qiskit 1.0 ([migration guide](https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0-features))
-- **QKT200**: Imports removed in Qiskit 2.0 ([migration guide](https://docs.quantum.ibm.com/migration-guides/qiskit-2.0))
+### Error codes
+
+| Code | What it detects |
+|------|-----------------|
+| **QKT100** | Import paths deprecated in Qiskit 1.0 ([migration guide](https://docs.quantum.ibm.com/api/migration-guides/qiskit-1.0-features)) |
+| **QKT101** | Method calls removed in Qiskit 1.0 (e.g. `.qasm()`, `.cnot()`, `.bind_parameters()`) |
+| **QKT102** | Keyword arguments removed in Qiskit 1.0 (e.g. `PassManager.append(max_iteration=...)`) |
+| **QKT200** | Import paths removed in Qiskit 2.0 ([migration guide](https://docs.quantum.ibm.com/migration-guides/qiskit-2.0)) |
+| **QKT201** | Method calls removed in Qiskit 2.0 (e.g. `.c_if()`, `.add_calibration()`, `.drive_channel()`) |
+| **QKT202** | Keyword arguments removed in Qiskit 2.0 (e.g. `transpile(backend_properties=...)`) |
+
+> [!NOTE]
+> QKT101/QKT102/QKT201 use heuristic detection (method name matching in files
+> that import `qiskit`). Without type inference, false positives are possible
+> but unlikely for the Qiskit-specific names we check. QKT202 tracks which
+> functions were imported from `qiskit` and has near-zero false positives.
 
 > [!WARNING]
-> This tool only detects deprecated import paths, it does not detect use of
-> deprecated methods (such as `QuantumCircuit.qasm`), deprecated arguments, or
-> assignments such as `qk = qiskit` (although it can handle _aliases_ such as
-> `import qiskit as qk`).
+> This tool does not detect assignments such as `qk = qiskit` (although it can
+> handle _aliases_ such as `import qiskit as qk`).
 
-This tool is to help you quickly identify deprecated imports and work out how
-to fix them. This tool is not perfect and will make some mistakes, so make sure
+This tool is to help you quickly identify deprecated API usage and work out how
+to fix it. This tool is not perfect and will make some mistakes, so make sure
 to test your project thoroughly after migrating.
 
 ## Through pipx
@@ -40,14 +52,17 @@ python -m venv .flake8-qiskit-migration-venv
 source .flake8-qiskit-migration-venv/bin/activate
 pip install flake8-qiskit-migration
 
-# Run all migration checks (QKT100 + QKT200)
+# Run all migration checks
 flake8 --select QKT <path-to-source>  # e.g. `src/`
 
-# Run only Qiskit 1.0 checks
-flake8 --select QKT100 <path-to-source>
+# Run only Qiskit 1.0 checks (imports + methods)
+flake8 --select QKT1 <path-to-source>
 
-# Run only Qiskit 2.0 checks
-flake8 --select QKT200 <path-to-source>
+# Run only Qiskit 2.0 checks (imports + methods + kwargs)
+flake8 --select QKT2 <path-to-source>
+
+# Run only import checks
+flake8 --select QKT100,QKT200 <path-to-source>
 
 # Run plugin on notebooks
 pip install nbqa
@@ -71,14 +86,14 @@ pip install flake8-qiskit-migration
 # Run all flake8 checks (including this plugin)
 flake8 <path-to-source>
 
-# Run only this plugin (both QKT100 and QKT200)
+# Run only this plugin (all checks)
 flake8 --select QKT <path-to-source>
 
 # Run only Qiskit 1.0 checks
-flake8 --select QKT100 <path-to-source>
+flake8 --select QKT1 <path-to-source>
 
 # Run only Qiskit 2.0 checks
-flake8 --select QKT200 <path-to-source>
+flake8 --select QKT2 <path-to-source>
 
 # Uninstall plugin
 pip uninstall flake8-qiskit-migration

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Flake8 plugin to detect deprecated/removed imports, methods, and arguments in Qi
 > QKT101/QKT102/QKT201 use heuristic detection (method name matching in files
 > that import `qiskit`). Without type inference, false positives are possible
 > but unlikely for the Qiskit-specific names we check. QKT202 tracks which
-> functions were imported from `qiskit` and has near-zero false positives.
+> functions were imported from `qiskit` and should have few false positives.
 
 > [!WARNING]
 > This tool does not detect assignments such as `qk = qiskit` (although it can

--- a/flake8_qiskit_migration/deprecated_kwargs.py
+++ b/flake8_qiskit_migration/deprecated_kwargs.py
@@ -1,0 +1,135 @@
+### This file contains removed keyword arguments for Qiskit 2.0 functions.
+### Dictionaries are in the form:
+###     ("full.import.path", "kwarg_name"): "advice to user"
+###
+### These are only flagged when the call target is confirmed to be
+### a function imported from qiskit (tracked by the Visitor).
+###
+### Functions that are re-exported at multiple paths need entries for
+### each path (e.g. `qiskit.transpile` and `qiskit.compiler.transpile`).
+
+DEPRECATED_KWARGS_V2 = {
+    # ----------------------------------------------------------------
+    # transpile() removed kwargs
+    # Common imports: `from qiskit import transpile`
+    #                 `from qiskit.compiler import transpile`
+    # ----------------------------------------------------------------
+    ("qiskit.transpile", "backend_properties"):
+        "The `backend_properties` argument of `transpile()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.transpile", "instruction_durations"):
+        "The `instruction_durations` argument of `transpile()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.transpile", "timing_constraints"):
+        "The `timing_constraints` argument of `transpile()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.transpile", "inst_map"):
+        "The `inst_map` argument of `transpile()` has been removed in Qiskit 2.0 as part of Pulse removal",
+
+    ("qiskit.compiler.transpile", "backend_properties"):
+        "The `backend_properties` argument of `transpile()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.compiler.transpile", "instruction_durations"):
+        "The `instruction_durations` argument of `transpile()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.compiler.transpile", "timing_constraints"):
+        "The `timing_constraints` argument of `transpile()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.compiler.transpile", "inst_map"):
+        "The `inst_map` argument of `transpile()` has been removed in Qiskit 2.0 as part of Pulse removal",
+
+    # ----------------------------------------------------------------
+    # generate_preset_pass_manager() removed kwargs
+    # Common imports: `from qiskit.transpiler import generate_preset_pass_manager`
+    #                 `from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager`
+    # ----------------------------------------------------------------
+    ("qiskit.transpiler.generate_preset_pass_manager", "backend_properties"):
+        "The `backend_properties` argument of `generate_preset_pass_manager()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.transpiler.generate_preset_pass_manager", "instruction_durations"):
+        "The `instruction_durations` argument of `generate_preset_pass_manager()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.transpiler.generate_preset_pass_manager", "timing_constraints"):
+        "The `timing_constraints` argument of `generate_preset_pass_manager()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.transpiler.generate_preset_pass_manager", "inst_map"):
+        "The `inst_map` argument of `generate_preset_pass_manager()` has been removed in Qiskit 2.0 as part of Pulse removal",
+
+    ("qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager", "backend_properties"):
+        "The `backend_properties` argument of `generate_preset_pass_manager()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager", "instruction_durations"):
+        "The `instruction_durations` argument of `generate_preset_pass_manager()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager", "timing_constraints"):
+        "The `timing_constraints` argument of `generate_preset_pass_manager()` has been removed in Qiskit 2.0; use `target` or `backend` instead",
+    ("qiskit.transpiler.preset_passmanagers.generate_preset_pass_manager", "inst_map"):
+        "The `inst_map` argument of `generate_preset_pass_manager()` has been removed in Qiskit 2.0 as part of Pulse removal",
+
+    # ----------------------------------------------------------------
+    # generate_routing_passmanager() — backend_properties removed
+    # ----------------------------------------------------------------
+    ("qiskit.transpiler.preset_passmanagers.common.generate_routing_passmanager", "backend_properties"):
+        "The `backend_properties` argument of `generate_routing_passmanager()` has been removed in Qiskit 2.0; use `target` instead",
+    ("qiskit.transpiler.preset_passmanagers.generate_routing_passmanager", "backend_properties"):
+        "The `backend_properties` argument of `generate_routing_passmanager()` has been removed in Qiskit 2.0; use `target` instead",
+
+    # ----------------------------------------------------------------
+    # generate_translation_passmanager() — backend_properties removed
+    # ----------------------------------------------------------------
+    ("qiskit.transpiler.preset_passmanagers.common.generate_translation_passmanager", "backend_properties"):
+        "The `backend_properties` argument of `generate_translation_passmanager()` has been removed in Qiskit 2.0; use `target` instead",
+    ("qiskit.transpiler.preset_passmanagers.generate_translation_passmanager", "backend_properties"):
+        "The `backend_properties` argument of `generate_translation_passmanager()` has been removed in Qiskit 2.0; use `target` instead",
+
+    # ----------------------------------------------------------------
+    # PassManagerConfig — backend_properties and inst_map removed
+    # ----------------------------------------------------------------
+    ("qiskit.transpiler.PassManagerConfig", "backend_properties"):
+        "The `backend_properties` argument of `PassManagerConfig()` has been removed in Qiskit 2.0; use `target` instead",
+    ("qiskit.transpiler.PassManagerConfig", "inst_map"):
+        "The `inst_map` argument of `PassManagerConfig()` has been removed in Qiskit 2.0 as part of Pulse removal",
+    ("qiskit.transpiler.passmanager_config.PassManagerConfig", "backend_properties"):
+        "The `backend_properties` argument of `PassManagerConfig()` has been removed in Qiskit 2.0; use `target` instead",
+    ("qiskit.transpiler.passmanager_config.PassManagerConfig", "inst_map"):
+        "The `inst_map` argument of `PassManagerConfig()` has been removed in Qiskit 2.0 as part of Pulse removal",
+
+    # ----------------------------------------------------------------
+    # Target.from_configuration() — backend_properties and inst_map removed
+    # ----------------------------------------------------------------
+    ("qiskit.transpiler.Target.from_configuration", "backend_properties"):
+        "The `backend_properties` argument of `Target.from_configuration()` has been removed in Qiskit 2.0",
+    ("qiskit.transpiler.Target.from_configuration", "inst_map"):
+        "The `inst_map` argument of `Target.from_configuration()` has been removed in Qiskit 2.0 as part of Pulse removal",
+    ("qiskit.transpiler.target.Target.from_configuration", "backend_properties"):
+        "The `backend_properties` argument of `Target.from_configuration()` has been removed in Qiskit 2.0",
+    ("qiskit.transpiler.target.Target.from_configuration", "inst_map"):
+        "The `inst_map` argument of `Target.from_configuration()` has been removed in Qiskit 2.0 as part of Pulse removal",
+
+    # ----------------------------------------------------------------
+    # Transpiler pass constructors — removed backend_properties-related args
+    # ----------------------------------------------------------------
+    ("qiskit.transpiler.passes.DenseLayout", "backend_prop"):
+        "The `backend_prop` argument of `DenseLayout()` has been removed in Qiskit 2.0; use `target` instead",
+    ("qiskit.transpiler.passes.layout.dense_layout.DenseLayout", "backend_prop"):
+        "The `backend_prop` argument of `DenseLayout()` has been removed in Qiskit 2.0; use `target` instead",
+
+    ("qiskit.transpiler.passes.VF2Layout", "properties"):
+        "The `properties` argument of `VF2Layout()` has been removed in Qiskit 2.0; use `target` instead",
+    ("qiskit.transpiler.passes.layout.vf2_layout.VF2Layout", "properties"):
+        "The `properties` argument of `VF2Layout()` has been removed in Qiskit 2.0; use `target` instead",
+
+    ("qiskit.transpiler.passes.VF2PostLayout", "properties"):
+        "The `properties` argument of `VF2PostLayout()` has been removed in Qiskit 2.0; use `target` instead",
+    ("qiskit.transpiler.passes.layout.vf2_post_layout.VF2PostLayout", "properties"):
+        "The `properties` argument of `VF2PostLayout()` has been removed in Qiskit 2.0; use `target` instead",
+
+    ("qiskit.transpiler.passes.UnitarySynthesis", "backend_props"):
+        "The `backend_props` argument of `UnitarySynthesis()` has been removed in Qiskit 2.0; use `target` instead",
+    ("qiskit.transpiler.passes.synthesis.unitary_synthesis.UnitarySynthesis", "backend_props"):
+        "The `backend_props` argument of `UnitarySynthesis()` has been removed in Qiskit 2.0; use `target` instead",
+}
+
+### ----------------------------------------------------------------
+### Qiskit 1.0 removed keyword arguments (method-name heuristic)
+### ----------------------------------------------------------------
+### These are keyed by (method_name, kwarg_name) and use the same
+### heuristic as QKT101: only flagged when the file imports qiskit.
+### The method + kwarg combination must be Qiskit-specific enough
+### to avoid false positives.
+
+DEPRECATED_METHOD_KWARGS_V1 = {
+    ("append", "max_iteration"):
+        "The `max_iteration` argument of `PassManager.append()` has been removed in Qiskit 1.0; use explicit flow controllers instead",
+    ("replace", "max_iteration"):
+        "The `max_iteration` argument of `PassManager.replace()` has been removed in Qiskit 1.0; use explicit flow controllers instead",
+}

--- a/flake8_qiskit_migration/deprecated_methods.py
+++ b/flake8_qiskit_migration/deprecated_methods.py
@@ -1,0 +1,53 @@
+### This file contains deprecated/removed method names for Qiskit 1.0 and 2.0.
+### Dictionaries are in the form:
+###     "method_name": "{} advice to user"
+### where `{}` will be replaced with `.method_name()`.
+###
+### These are only flagged when the file imports from `qiskit`.
+### Without type inference we can't know the receiver type, so we
+### restrict to method names specific enough to avoid false positives.
+
+DEPRECATED_METHODS_V1 = {
+    # QuantumCircuit / Instruction / Register .qasm() removed
+    "qasm": "{} has been removed in Qiskit 1.0; use `qiskit.qasm2.dumps(circuit)` instead",
+    # QuantumCircuit.bind_parameters → .assign_parameters()
+    "bind_parameters": "{} has been removed in Qiskit 1.0; use `.assign_parameters()` instead",
+    # Removed QC gate aliases
+    "cnot": "{} has been removed in Qiskit 1.0; use `.cx()` instead",
+    "toffoli": "{} has been removed in Qiskit 1.0; use `.ccx()` instead",
+    "fredkin": "{} has been removed in Qiskit 1.0; use `.cswap()` instead",
+    "mct": "{} has been removed in Qiskit 1.0; use `.mcx()` instead",
+    # Removed QC methods (from qiskit.extensions removal)
+    "snapshot": "{} has been removed in Qiskit 1.0; use Aer save instructions instead",
+    "squ": "{} has been removed in Qiskit 1.0; use `.append(UnitaryGate(...))` instead",
+    "diagonal": "{} has been removed in Qiskit 1.0; use `.append(DiagonalGate(...))` instead",
+    "hamiltonian": "{} has been removed in Qiskit 1.0; use `.append(HamiltonianGate(...))` instead",
+    "isometry": "{} has been removed in Qiskit 1.0; use `.append(Isometry(...))` instead",
+    "iso": "{} has been removed in Qiskit 1.0; use `.append(Isometry(...))` instead",
+    "uc": "{} has been removed in Qiskit 1.0; use `.append(UCGate(...))` instead",
+    "ucrx": "{} has been removed in Qiskit 1.0; use `.append(UCRXGate(...))` instead",
+    "ucry": "{} has been removed in Qiskit 1.0; use `.append(UCRYGate(...))` instead",
+    "ucrz": "{} has been removed in Qiskit 1.0; use `.append(UCRZGate(...))` instead",
+}
+
+DEPRECATED_METHODS_V2 = {
+    # Instruction / InstructionSet .c_if() → if_test context manager
+    "c_if": "{} has been removed in Qiskit 2.0; use the `if_test` context manager instead",
+    # Instruction.condition_bits() removed with c_if
+    "condition_bits": "{} has been removed in Qiskit 2.0; use `IfElseOp` instead",
+    # QuantumCircuit / DAGCircuit calibration methods (Pulse removal)
+    "add_calibration": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "has_calibration_for": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    # BackendV2 channel methods (Pulse removal)
+    "instruction_schedule_map": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "drive_channel": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "measure_channel": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "acquire_channel": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "control_channel": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    # Target methods (Pulse removal)
+    "has_calibration": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "get_calibration": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "update_from_instruction_schedule_map": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    # Target.target_to_backend_properties()
+    "target_to_backend_properties": "{} has been removed in Qiskit 2.0",
+}

--- a/flake8_qiskit_migration/deprecated_methods.py
+++ b/flake8_qiskit_migration/deprecated_methods.py
@@ -9,45 +9,45 @@
 
 DEPRECATED_METHODS_V1 = {
     # QuantumCircuit / Instruction / Register .qasm() removed
-    "qasm": "QuantumCircuit.{} has been removed in Qiskit 1.0; use `qiskit.qasm2.dumps(circuit)` instead",
+    "qasm": "QuantumCircuit{} has been removed in Qiskit 1.0; use `qiskit.qasm2.dumps(circuit)` instead",
     # QuantumCircuit.bind_parameters → .assign_parameters()
-    "bind_parameters": "{} has been removed in Qiskit 1.0; use `.assign_parameters()` instead",
+    "bind_parameters": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.assign_parameters()` instead",
     # Removed QC gate aliases
-    "cnot": "{} has been removed in Qiskit 1.0; use `.cx()` instead",
-    "toffoli": "{} has been removed in Qiskit 1.0; use `.ccx()` instead",
-    "fredkin": "{} has been removed in Qiskit 1.0; use `.cswap()` instead",
-    "mct": "{} has been removed in Qiskit 1.0; use `.mcx()` instead",
+    "cnot": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.cx()` instead",
+    "toffoli": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.ccx()` instead",
+    "fredkin": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.cswap()` instead",
+    "mct": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.mcx()` instead",
     # Removed QC methods (from qiskit.extensions removal)
-    "snapshot": "{} has been removed in Qiskit 1.0; use Aer save instructions instead",
-    "squ": "{} has been removed in Qiskit 1.0; use `.append(UnitaryGate(...))` instead",
-    "diagonal": "{} has been removed in Qiskit 1.0; use `.append(DiagonalGate(...))` instead",
-    "hamiltonian": "{} has been removed in Qiskit 1.0; use `.append(HamiltonianGate(...))` instead",
-    "isometry": "{} has been removed in Qiskit 1.0; use `.append(Isometry(...))` instead",
-    "iso": "{} has been removed in Qiskit 1.0; use `.append(Isometry(...))` instead",
-    "uc": "{} has been removed in Qiskit 1.0; use `.append(UCGate(...))` instead",
-    "ucrx": "{} has been removed in Qiskit 1.0; use `.append(UCRXGate(...))` instead",
-    "ucry": "{} has been removed in Qiskit 1.0; use `.append(UCRYGate(...))` instead",
-    "ucrz": "{} has been removed in Qiskit 1.0; use `.append(UCRZGate(...))` instead",
+    "snapshot": "QuantumCircuit{} has been removed in Qiskit 1.0; use Aer save instructions instead",
+    "squ": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.append(UnitaryGate(...))` instead",
+    "diagonal": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.append(DiagonalGate(...))` instead",
+    "hamiltonian": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.append(HamiltonianGate(...))` instead",
+    "isometry": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.append(Isometry(...))` instead",
+    "iso": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.append(Isometry(...))` instead",
+    "uc": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.append(UCGate(...))` instead",
+    "ucrx": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.append(UCRXGate(...))` instead",
+    "ucry": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.append(UCRYGate(...))` instead",
+    "ucrz": "QuantumCircuit{} has been removed in Qiskit 1.0; use `.append(UCRZGate(...))` instead",
 }
 
 DEPRECATED_METHODS_V2 = {
     # Instruction / InstructionSet .c_if() → if_test context manager
-    "c_if": "{} has been removed in Qiskit 2.0; use the `if_test` context manager instead",
+    "c_if": "Instruction{} has been removed in Qiskit 2.0; use the `if_test` context manager instead",
     # Instruction.condition_bits() removed with c_if
-    "condition_bits": "{} has been removed in Qiskit 2.0; use `IfElseOp` instead",
+    "condition_bits": "Instruction{} has been removed in Qiskit 2.0; use `IfElseOp` instead",
     # QuantumCircuit / DAGCircuit calibration methods (Pulse removal)
-    "add_calibration": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
-    "has_calibration_for": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "add_calibration": "QuantumCircuit{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "has_calibration_for": "QuantumCircuit{} has been removed in Qiskit 2.0 as part of Pulse removal",
     # BackendV2 channel methods (Pulse removal)
-    "instruction_schedule_map": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
-    "drive_channel": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
-    "measure_channel": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
-    "acquire_channel": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
-    "control_channel": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "instruction_schedule_map": "BackendV2{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "drive_channel": "BackendV2{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "measure_channel": "BackendV2{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "acquire_channel": "BackendV2{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "control_channel": "BackendV2{} has been removed in Qiskit 2.0 as part of Pulse removal",
     # Target methods (Pulse removal)
-    "has_calibration": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
-    "get_calibration": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
-    "update_from_instruction_schedule_map": "{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "has_calibration": "Target{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "get_calibration": "Target{} has been removed in Qiskit 2.0 as part of Pulse removal",
+    "update_from_instruction_schedule_map": "Target{} has been removed in Qiskit 2.0 as part of Pulse removal",
     # Target.target_to_backend_properties()
-    "target_to_backend_properties": "{} has been removed in Qiskit 2.0",
+    "target_to_backend_properties": "Target{} has been removed in Qiskit 2.0",
 }

--- a/flake8_qiskit_migration/deprecated_methods.py
+++ b/flake8_qiskit_migration/deprecated_methods.py
@@ -9,7 +9,7 @@
 
 DEPRECATED_METHODS_V1 = {
     # QuantumCircuit / Instruction / Register .qasm() removed
-    "qasm": "{} has been removed in Qiskit 1.0; use `qiskit.qasm2.dumps(circuit)` instead",
+    "qasm": "QuantumCircuit.{} has been removed in Qiskit 1.0; use `qiskit.qasm2.dumps(circuit)` instead",
     # QuantumCircuit.bind_parameters → .assign_parameters()
     "bind_parameters": "{} has been removed in Qiskit 1.0; use `.assign_parameters()` instead",
     # Removed QC gate aliases

--- a/flake8_qiskit_migration/plugin.py
+++ b/flake8_qiskit_migration/plugin.py
@@ -6,10 +6,25 @@ import importlib.metadata
 
 from .deprecated_paths import DEPRECATED_PATHS, EXCEPTIONS
 from .deprecated_paths_v2 import DEPRECATED_PATHS_V2, EXCEPTIONS_V2
+from .deprecated_methods import DEPRECATED_METHODS_V1, DEPRECATED_METHODS_V2
+from .deprecated_kwargs import DEPRECATED_KWARGS_V2, DEPRECATED_METHOD_KWARGS_V1
 
 RULE_SETS = [
     ("QKT100", DEPRECATED_PATHS, EXCEPTIONS),
     ("QKT200", DEPRECATED_PATHS_V2, EXCEPTIONS_V2),
+]
+
+METHOD_RULE_SETS = [
+    ("QKT101", DEPRECATED_METHODS_V1),
+    ("QKT201", DEPRECATED_METHODS_V2),
+]
+
+KWARG_RULE_SETS = [
+    ("QKT202", DEPRECATED_KWARGS_V2),
+]
+
+METHOD_KWARG_RULE_SETS = [
+    ("QKT102", DEPRECATED_METHOD_KWARGS_V1),
 ]
 
 
@@ -50,23 +65,40 @@ def deprecation_messages(path: str, original_import_path: str | None = None) -> 
     return messages
 
 
+def _get_dotted_name(node: ast.expr) -> str | None:
+    """Reconstruct a dotted name from an AST node (Name or Attribute chain)."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = _get_dotted_name(node.value)
+        if parent is not None:
+            return f"{parent}.{node.attr}"
+    return None
+
+
 class Visitor(ast.NodeVisitor):
     """
-    Simple visitor to detect deprecated imports. Includes some support for
-    aliases and scopes, but not assignments.
+    Visitor to detect deprecated imports, method calls, and keyword arguments.
+    Includes support for aliases and scopes, but not assignments.
     """
 
     def __init__(self):
         self.problems: list[Problem] = []
         self.mappings: list[dict[str, str]] = [{}]  # track aliases for each scope
+        self.imports_qiskit: bool = False  # set True if any qiskit import is found
+        # Maps local name → full qiskit import path for from-imports
+        # e.g. {"transpile": "qiskit.compiler.transpile"}
+        self.qiskit_functions: list[dict[str, str]] = [{}]  # scoped like mappings
 
     def enter_scope(self) -> None:
         """Add new mapping for scoped aliases"""
         self.mappings.append({})
+        self.qiskit_functions.append({})
 
     def exit_scope(self) -> None:
         """Delete scoped aliases"""
         self.mappings.pop()
+        self.qiskit_functions.pop()
 
     def add_alias(self, alias: ast.alias) -> None:
         if alias.asname is None or alias.asname == alias.name:
@@ -77,6 +109,34 @@ class Visitor(ast.NodeVisitor):
         for mapping in reversed(self.mappings):
             name = mapping.get(name, name)
         return name
+
+    def _resolve_func_path(self, node: ast.expr) -> str | None:
+        """Resolve a function call target to a full qiskit import path, or None."""
+        if isinstance(node, ast.Name):
+            # Look up in qiskit_functions (scoped)
+            for scope in reversed(self.qiskit_functions):
+                if node.id in scope:
+                    return scope[node.id]
+            return None
+        if isinstance(node, ast.Attribute):
+            # Build dotted path and resolve aliases
+            dotted = _get_dotted_name(node)
+            if dotted is None:
+                return None
+            parts = dotted.split(".", 1)
+            root = parts[0]
+            rest = parts[1] if len(parts) > 1 else ""
+            # First try qiskit_functions for the root (e.g. Target → qiskit.transpiler.Target)
+            for scope in reversed(self.qiskit_functions):
+                if root in scope:
+                    full_root = scope[root]
+                    return f"{full_root}.{rest}" if rest else full_root
+            # Then try alias resolution (e.g. qk → qiskit)
+            resolved_root = self.resolve_aliases(root)
+            resolved = f"{resolved_root}.{rest}" if rest else resolved_root
+            if resolved.startswith("qiskit."):
+                return resolved
+        return None
 
     def report_if_deprecated(self, path: str, node) -> bool:
         """
@@ -91,13 +151,21 @@ class Visitor(ast.NodeVisitor):
     def visit_Import(self, node: ast.Import) -> None:
         for alias in node.names:
             self.add_alias(alias)
+            if alias.name.startswith("qiskit"):
+                self.imports_qiskit = True
             self.report_if_deprecated(alias.name, node)
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if node.module and node.module.startswith("qiskit"):
+            self.imports_qiskit = True
         for alias in node.names:
             self.add_alias(alias)
             path = f"{node.module}.{alias.name}"
+            # Track the local name → full qiskit path for kwarg checking
+            if node.module and node.module.startswith("qiskit"):
+                local_name = alias.asname if alias.asname else alias.name
+                self.qiskit_functions[-1][local_name] = path
             self.report_if_deprecated(path, node)
         self.generic_visit(node)
 
@@ -113,6 +181,37 @@ class Visitor(ast.NodeVisitor):
         path = _get_parents(node)
         if not self.report_if_deprecated(path, node):
             self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        # A) Check for deprecated method calls (e.g. obj.c_if(), qc.qasm())
+        if isinstance(node.func, ast.Attribute) and self.imports_qiskit:
+            method_name = node.func.attr
+            for prefix, methods_dict in METHOD_RULE_SETS:
+                if method_name in methods_dict:
+                    msg = f"{prefix}: " + methods_dict[method_name].format(
+                        f".{method_name}()"
+                    )
+                    self.problems.append(Problem(node, msg))
+
+        # B) Check for deprecated kwargs on known qiskit functions
+        func_path = self._resolve_func_path(node.func)
+        if func_path and node.keywords:
+            for prefix, kwargs_dict in KWARG_RULE_SETS:
+                for kw in node.keywords:
+                    if kw.arg and (func_path, kw.arg) in kwargs_dict:
+                        msg = f"{prefix}: " + kwargs_dict[(func_path, kw.arg)]
+                        self.problems.append(Problem(node, msg))
+
+        # C) Check for deprecated kwargs on method calls (heuristic)
+        if isinstance(node.func, ast.Attribute) and self.imports_qiskit and node.keywords:
+            method_name = node.func.attr
+            for prefix, method_kwargs_dict in METHOD_KWARG_RULE_SETS:
+                for kw in node.keywords:
+                    if kw.arg and (method_name, kw.arg) in method_kwargs_dict:
+                        msg = f"{prefix}: " + method_kwargs_dict[(method_name, kw.arg)]
+                        self.problems.append(Problem(node, msg))
+
+        self.generic_visit(node)
 
     # Push / pop scopes for aliases
     def visit_FunctionDef(self, node: ast.FunctionDef):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ dependencies = [ "flake8", ]
 authors = [
   { name="Frank Harkins", email="frankharkins@hotmail.co.uk" },
 ]
-description = "Quickly detect deprecated/removed imports in Qiskit 1.0 and 2.0"
+description = "Detect deprecated/removed imports, methods, and arguments in Qiskit 1.0 and 2.0"
 readme = "README.md"
 requires-python = ">=3.8"
 classifiers = [
@@ -20,7 +20,11 @@ Issues = "https://github.com/frankharkins/flake8-qiskit-migration/issues"
 
 [project.entry-points."flake8.extension"]
 QKT100 = "flake8_qiskit_migration.plugin:Plugin"
+QKT101 = "flake8_qiskit_migration.plugin:Plugin"
+QKT102 = "flake8_qiskit_migration.plugin:Plugin"
 QKT200 = "flake8_qiskit_migration.plugin:Plugin"
+QKT201 = "flake8_qiskit_migration.plugin:Plugin"
+QKT202 = "flake8_qiskit_migration.plugin:Plugin"
 
 [project.scripts]
 flake8-qiskit-migration = "flake8_qiskit_migration.command:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,7 @@ Homepage = "https://github.com/frankharkins/flake8-qiskit-migration"
 Issues = "https://github.com/frankharkins/flake8-qiskit-migration/issues"
 
 [project.entry-points."flake8.extension"]
-QKT100 = "flake8_qiskit_migration.plugin:Plugin"
-QKT101 = "flake8_qiskit_migration.plugin:Plugin"
-QKT102 = "flake8_qiskit_migration.plugin:Plugin"
-QKT200 = "flake8_qiskit_migration.plugin:Plugin"
-QKT201 = "flake8_qiskit_migration.plugin:Plugin"
-QKT202 = "flake8_qiskit_migration.plugin:Plugin"
+QKT = "flake8_qiskit_migration.plugin:Plugin"
 
 [project.scripts]
 flake8-qiskit-migration = "flake8_qiskit_migration.command:cli"

--- a/tests/test.py
+++ b/tests/test.py
@@ -337,3 +337,400 @@ def test_dual_message_pulse_specific():
     qkt200 = {r for r in results if "QKT200" in r}
     assert len(qkt100) == 1
     assert len(qkt200) == 1
+
+
+# ---- QKT101 tests (Qiskit 1.0 removed methods) ----
+
+def test_removed_qasm_method():
+    """QuantumCircuit.qasm() was removed in Qiskit 1.0."""
+    code = """
+    from qiskit.circuit import QuantumCircuit
+    qc = QuantumCircuit(2)
+    qc.qasm()
+    """
+    results = _results(code)
+    qkt101 = {r for r in results if "QKT101" in r}
+    assert len(qkt101) == 1
+    assert any(".qasm()" in r for r in qkt101)
+
+
+def test_removed_bind_parameters():
+    """QuantumCircuit.bind_parameters() → .assign_parameters()."""
+    code = """
+    from qiskit.circuit import QuantumCircuit
+    qc = QuantumCircuit(2)
+    qc.bind_parameters({})
+    """
+    results = _results(code)
+    qkt101 = {r for r in results if "QKT101" in r}
+    assert len(qkt101) == 1
+    assert any(".bind_parameters()" in r for r in qkt101)
+
+
+def test_removed_qc_aliases():
+    """Removed QC convenience method aliases."""
+    code = """
+    from qiskit.circuit import QuantumCircuit
+    qc = QuantumCircuit(3)
+    qc.cnot(0, 1)
+    qc.toffoli(0, 1, 2)
+    qc.fredkin(0, 1, 2)
+    qc.mct([0, 1], 2)
+    """
+    results = _results(code)
+    qkt101 = {r for r in results if "QKT101" in r}
+    assert any(".cnot()" in r for r in qkt101)
+    assert any(".toffoli()" in r for r in qkt101)
+    assert any(".fredkin()" in r for r in qkt101)
+    assert any(".mct()" in r for r in qkt101)
+
+
+def test_removed_extension_methods():
+    """Removed QC methods from extensions module."""
+    code = """
+    from qiskit.circuit import QuantumCircuit
+    qc = QuantumCircuit(2)
+    qc.snapshot("snap")
+    qc.squ([[1, 0], [0, 1]], 0)
+    qc.diagonal([1, 1, 1, -1])
+    qc.isometry([[1, 0], [0, 1]], [0], [])
+    qc.ucrx([0.1], 0, 1)
+    """
+    results = _results(code)
+    qkt101 = {r for r in results if "QKT101" in r}
+    assert any(".snapshot()" in r for r in qkt101)
+    assert any(".squ()" in r for r in qkt101)
+    assert any(".diagonal()" in r for r in qkt101)
+    assert any(".isometry()" in r for r in qkt101)
+    assert any(".ucrx()" in r for r in qkt101)
+
+
+def test_no_method_false_positive_without_qiskit():
+    """Methods should NOT be flagged if the file doesn't import qiskit."""
+    code = """
+    import some_other_library
+    obj = some_other_library.Thing()
+    obj.qasm()
+    obj.c_if(x, 1)
+    obj.bind_parameters({})
+    """
+    assert _results(code) == set()
+
+
+# ---- QKT102 tests (Qiskit 1.0 removed keyword arguments, heuristic) ----
+
+def test_pass_manager_append_max_iteration():
+    """PassManager.append(max_iteration=...) removed in 1.0."""
+    code = """
+    from qiskit.transpiler import PassManager
+    pm = PassManager()
+    pm.append(my_pass, max_iteration=5)
+    """
+    results = _results(code)
+    qkt102 = {r for r in results if "QKT102" in r}
+    assert len(qkt102) == 1
+    assert any("max_iteration" in r for r in qkt102)
+
+
+def test_pass_manager_replace_max_iteration():
+    """PassManager.replace(max_iteration=...) removed in 1.0."""
+    code = """
+    from qiskit.transpiler import PassManager
+    pm = PassManager()
+    pm.replace(0, my_pass, max_iteration=3)
+    """
+    results = _results(code)
+    qkt102 = {r for r in results if "QKT102" in r}
+    assert len(qkt102) == 1
+    assert any("max_iteration" in r for r in qkt102)
+
+
+def test_method_kwarg_no_false_positive_without_qiskit():
+    """append(max_iteration=...) without qiskit import should NOT trigger."""
+    code = """
+    import some_library
+    pm = some_library.Manager()
+    pm.append(task, max_iteration=5)
+    """
+    assert _results(code) == set()
+
+
+# ---- QKT201 tests (Qiskit 2.0 removed methods) ----
+
+def test_c_if_removal():
+    """Instruction.c_if() / InstructionSet.c_if() removed in 2.0."""
+    code = """
+    from qiskit.circuit import QuantumCircuit
+    qc = QuantumCircuit(2, 2)
+    qc.measure(0, 0)
+    qc.x(1).c_if(0, 1)
+    """
+    results = _results(code)
+    qkt201 = {r for r in results if "QKT201" in r}
+    assert len(qkt201) == 1
+    assert any(".c_if()" in r and "if_test" in r for r in qkt201)
+
+
+def test_calibration_methods_removal():
+    """QC calibration methods removed in 2.0 (Pulse removal)."""
+    code = """
+    from qiskit.circuit import QuantumCircuit
+    qc = QuantumCircuit(2)
+    qc.add_calibration("x", [0], None)
+    qc.has_calibration_for(None)
+    """
+    results = _results(code)
+    qkt201 = {r for r in results if "QKT201" in r}
+    assert any("add_calibration" in r for r in qkt201)
+    assert any("has_calibration_for" in r for r in qkt201)
+
+
+def test_backend_channel_methods():
+    """BackendV2 channel methods removed in 2.0 (Pulse removal)."""
+    code = """
+    from qiskit.providers import BackendV2
+    backend = BackendV2()
+    backend.drive_channel(0)
+    backend.measure_channel(0)
+    backend.acquire_channel(0)
+    backend.control_channel((0, 1))
+    """
+    results = _results(code)
+    qkt201 = {r for r in results if "QKT201" in r}
+    assert any("drive_channel" in r for r in qkt201)
+    assert any("measure_channel" in r for r in qkt201)
+    assert any("acquire_channel" in r for r in qkt201)
+    assert any("control_channel" in r for r in qkt201)
+
+
+def test_target_pulse_methods():
+    """Target pulse-related methods removed in 2.0."""
+    code = """
+    from qiskit.transpiler import Target
+    t = Target()
+    t.has_calibration("cx", (0, 1))
+    t.get_calibration("cx", (0, 1))
+    t.instruction_schedule_map()
+    t.update_from_instruction_schedule_map(None)
+    """
+    results = _results(code)
+    qkt201 = {r for r in results if "QKT201" in r}
+    assert any("has_calibration" in r for r in qkt201)
+    assert any("get_calibration" in r for r in qkt201)
+    assert any("instruction_schedule_map" in r for r in qkt201)
+    assert any("update_from_instruction_schedule_map" in r for r in qkt201)
+
+
+def test_condition_bits_removal():
+    """Instruction.condition_bits() removed in 2.0."""
+    code = """
+    from qiskit.circuit import QuantumCircuit
+    qc = QuantumCircuit(2, 2)
+    inst = qc.data[0]
+    inst.operation.condition_bits()
+    """
+    results = _results(code)
+    qkt201 = {r for r in results if "QKT201" in r}
+    assert any("condition_bits" in r for r in qkt201)
+
+
+# ---- QKT202 tests (Qiskit 2.0 removed keyword arguments) ----
+
+def test_transpile_removed_kwargs():
+    """transpile() removed kwargs in 2.0."""
+    code = """
+    from qiskit.compiler import transpile
+    transpile(qc, backend_properties=props)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 1
+    assert any("backend_properties" in r for r in qkt202)
+
+
+def test_transpile_multiple_removed_kwargs():
+    """Multiple removed kwargs on a single transpile() call."""
+    code = """
+    from qiskit.compiler import transpile
+    transpile(qc, backend_properties=props, inst_map=imap, timing_constraints=tc)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 3
+    assert any("backend_properties" in r for r in qkt202)
+    assert any("inst_map" in r for r in qkt202)
+    assert any("timing_constraints" in r for r in qkt202)
+
+
+def test_generate_pm_removed_kwargs():
+    """generate_preset_pass_manager() removed kwargs in 2.0."""
+    code = """
+    from qiskit.transpiler import generate_preset_pass_manager
+    generate_preset_pass_manager(backend_properties=props, inst_map=imap)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 2
+    assert any("backend_properties" in r for r in qkt202)
+    assert any("inst_map" in r for r in qkt202)
+
+
+def test_transpile_aliased():
+    """transpile() with alias should still detect removed kwargs."""
+    code = """
+    from qiskit.compiler import transpile as tp
+    tp(qc, backend_properties=props)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 1
+
+
+def test_transpile_dotted_call():
+    """qiskit.compiler.transpile() via dotted access should detect removed kwargs."""
+    code = """
+    import qiskit.compiler
+    qiskit.compiler.transpile(qc, backend_properties=props)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 1
+
+
+def test_transpile_bare_import_dotted_call():
+    """import qiskit; qiskit.transpile(...) should detect removed kwargs."""
+    code = """
+    import qiskit
+    qiskit.transpile(qc, backend_properties=props)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 1
+    assert any("backend_properties" in r for r in qkt202)
+
+
+def test_kwarg_no_false_positive_other_library():
+    """transpile from another library should NOT trigger QKT202."""
+    code = """
+    from my_library import transpile
+    transpile(backend_properties=props)
+    """
+    assert _results(code) == set()
+
+
+def test_kwarg_no_false_positive_valid_kwargs():
+    """Valid transpile kwargs should NOT trigger QKT202."""
+    code = """
+    from qiskit.compiler import transpile
+    transpile(qc, target=target, optimization_level=2)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 0
+
+
+def test_target_from_configuration_kwargs():
+    """Target.from_configuration() removed kwargs."""
+    code = """
+    from qiskit.transpiler import Target
+    Target.from_configuration(num_qubits=2, inst_map=imap)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 1
+    assert any("inst_map" in r for r in qkt202)
+
+
+def test_transpile_reexported_path():
+    """from qiskit import transpile (re-exported) should detect removed kwargs."""
+    code = """
+    from qiskit import transpile
+    transpile(qc, backend_properties=props)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 1
+    assert any("backend_properties" in r for r in qkt202)
+
+
+def test_transpile_reexported_all_kwargs():
+    """All four removed transpile() kwargs via re-exported path."""
+    code = """
+    from qiskit import transpile
+    transpile(qc, backend_properties=p, instruction_durations=d, timing_constraints=t, inst_map=i)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 4
+
+
+def test_generate_pm_reexported_path():
+    """generate_preset_pass_manager via preset_passmanagers submodule."""
+    code = """
+    from qiskit.transpiler.preset_passmanagers import generate_preset_pass_manager
+    generate_preset_pass_manager(backend_properties=props, timing_constraints=tc)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 2
+
+
+def test_pass_manager_config_kwargs():
+    """PassManagerConfig removed kwargs (backend_properties and inst_map)."""
+    code = """
+    from qiskit.transpiler import PassManagerConfig
+    PassManagerConfig(backend_properties=props, inst_map=imap)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 2
+    assert any("backend_properties" in r for r in qkt202)
+    assert any("inst_map" in r for r in qkt202)
+
+
+def test_dense_layout_backend_prop():
+    """DenseLayout(backend_prop=...) removed in 2.0."""
+    code = """
+    from qiskit.transpiler.passes import DenseLayout
+    DenseLayout(backend_prop=props)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 1
+    assert any("backend_prop" in r for r in qkt202)
+
+
+def test_vf2_layout_properties():
+    """VF2Layout(properties=...) removed in 2.0."""
+    code = """
+    from qiskit.transpiler.passes import VF2Layout
+    VF2Layout(properties=props)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 1
+    assert any("properties" in r for r in qkt202)
+
+
+def test_vf2_post_layout_properties():
+    """VF2PostLayout(properties=...) removed in 2.0."""
+    code = """
+    from qiskit.transpiler.passes import VF2PostLayout
+    VF2PostLayout(properties=props)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 1
+    assert any("properties" in r for r in qkt202)
+
+
+def test_unitary_synthesis_backend_props():
+    """UnitarySynthesis(backend_props=...) removed in 2.0."""
+    code = """
+    from qiskit.transpiler.passes import UnitarySynthesis
+    UnitarySynthesis(backend_props=props)
+    """
+    results = _results(code)
+    qkt202 = {r for r in results if "QKT202" in r}
+    assert len(qkt202) == 1
+    assert any("backend_props" in r for r in qkt202)


### PR DESCRIPTION
## Summary

Stacks on top of https://github.com/qiskit-community/flake8-qiskit-migration/pull/1

- Adds 4 new error codes to detect removed methods and keyword arguments across Qiskit 1.0 and 2.0
- **QKT101**: Qiskit 1.0 removed methods (`.qasm()`, `.cnot()`, `.bind_parameters()`, `.snapshot()`, etc.)
- **QKT102**: Qiskit 1.0 removed keyword arguments (`PassManager.append(max_iteration=...)`)
- **QKT201**: Qiskit 2.0 removed methods (`.c_if()`, `.add_calibration()`, `.drive_channel()`, etc.)
- **QKT202**: Qiskit 2.0 removed keyword arguments (`transpile(backend_properties=...)`, `generate_preset_pass_manager(inst_map=...)`, `DenseLayout(backend_prop=...)`, etc.)
- 30 new tests (59 total), all passing

## Detection approaches

| Code | Mechanism | False positive risk |
|------|-----------|-------------------|
| QKT101/QKT201 | Method name matching in files that import `qiskit` | Low (Qiskit-specific names) |
| QKT102 | Method name + kwarg name matching in files that import `qiskit` | Very low |
| QKT202 | Tracks imported function paths, checks kwargs precisely | Near-zero |