### PR TITLE
Update publish action

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -43,4 +43,4 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Switches to the version listed on https://docs.pypi.org/trusted-publishers/using-a-publisher/ to hopefully fix the next problem in the publishing action.
